### PR TITLE
chore: fix typo of AsoulCnki

### DIFF
--- a/src/views/DuplicateChecking.vue
+++ b/src/views/DuplicateChecking.vue
@@ -1,5 +1,5 @@
 <template>
-  <headerTitle title="知网查重" sub-title="帮助你快速识别原创小作文" @buttonClick="changeIntroduceShow"></headerTitle>
+  <headerTitle title="枝网查重" sub-title="帮助你快速识别原创小作文" @buttonClick="changeIntroduceShow"></headerTitle>
   <div v-show="isShowIntroduce" class="introduce-phone">
     <div class="introduce-title">功能介绍</div>
     <div v-for="(item, index) in contentList" :key="index" class="introduce-text-content">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32223541/146025078-0682fab0-f2b8-4bb5-a03a-775d090685ce.png)

如图，“枝网查重”在标题中被误写作“知网查重”。
鉴于知网查重是正主，有点不合礼法，故修改之。